### PR TITLE
Added highlight ignore rule for <Int

### DIFF
--- a/nano/k.nanorc
+++ b/nano/k.nanorc
@@ -14,3 +14,7 @@ color green start="/\*" end="\*/"
 
 #Because regex-based syntax highlighting is limited, it can be annoying if expressions are mis-highlighted. This provides a way to ignore syntax highlighting in a whole file.
 color white,black start="^//<K-IGNORE-NANO-HIGHLIGHT>$" end="^//</K-IGNORE-NANO-HIGHLIGHT>$"
+
+#Here are automatically-applied highlighting ignore rules for known false positives with the syntax highlighting.
+color white start="<(\/)?Int" end=">"
+


### PR DESCRIPTION
The existing rule is picking it up as a cell, when there is a > sign on the same line - this is wrong.
The new rule just resets the colour to white in this case.

Before the change:

![image](https://user-images.githubusercontent.com/14222121/164683221-8f150d63-bc15-4a60-884e-41969ed47fe1.png)

After the change:

![image](https://user-images.githubusercontent.com/14222121/164683246-fe31c425-a723-4c93-a05e-6c7cf09dfaac.png)